### PR TITLE
feat: Routine Preview Screen

### DIFF
--- a/__tests__/screens/routine-preview-routes.test.ts
+++ b/__tests__/screens/routine-preview-routes.test.ts
@@ -1,0 +1,156 @@
+// Tests for routine preview route params validation
+import {
+  routinePreviewParamsSchema,
+  routineEditorParamsSchema,
+  safeParseParams,
+} from '@/src/validators/routes';
+
+describe('Routine Preview Route Params', () => {
+
+  describe('routinePreviewParamsSchema', () => {
+    it('validates valid preview params', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '5',
+        routineName: 'Treino A (Push/Legs)',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.routineId).toBe(5);
+        expect(result.data.routineName).toBe('Treino A (Push/Legs)');
+      }
+    });
+
+    it('validates with only routineId (routineName optional)', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '10',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.routineId).toBe(10);
+        expect(result.data.routineName).toBe('');
+      }
+    });
+
+    it('coerces string routineId to number', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '42',
+        routineName: 'Leg Day',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.routineId).toBe(42);
+        expect(typeof result.data.routineId).toBe('number');
+      }
+    });
+
+    it('rejects empty routineId', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '',
+        routineName: 'Test',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-numeric routineId', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: 'abc',
+        routineName: 'Test',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects negative routineId', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '-5',
+        routineName: 'Test',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects zero routineId', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '0',
+        routineName: 'Test',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects decimal routineId', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '3.14',
+        routineName: 'Test',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('handles routineName with special characters', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '1',
+        routineName: 'Treino A (Push/Legs) — Avançado',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.routineName).toBe('Treino A (Push/Legs) \u2014 Avançado');
+      }
+    });
+
+    it('handles large routineId', () => {
+      const result = routinePreviewParamsSchema.safeParse({
+        routineId: '999999',
+        routineName: 'Test',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.routineId).toBe(999999);
+      }
+    });
+  });
+
+  describe('routineEditorParamsSchema (Edit button target)', () => {
+    it('validates with id param', () => {
+      const result = routineEditorParamsSchema.safeParse({
+        id: '5',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.id).toBe('5');
+      }
+    });
+
+    it('validates without id param (optional)', () => {
+      const result = routineEditorParamsSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('safeParseParams with routinePreviewParamsSchema', () => {
+    it('returns parsed data for valid params', () => {
+      const result = safeParseParams(
+        routinePreviewParamsSchema,
+        { routineId: '7', routineName: 'Upper A' },
+        'RoutinePreview'
+      );
+      expect(result).not.toBeNull();
+      expect(result!.routineId).toBe(7);
+      expect(result!.routineName).toBe('Upper A');
+    });
+
+    it('returns null for invalid params', () => {
+      const result = safeParseParams(
+        routinePreviewParamsSchema,
+        { routineId: 'not-a-number' },
+        'RoutinePreview'
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null for missing routineId', () => {
+      const result = safeParseParams(
+        routinePreviewParamsSchema,
+        { routineName: 'Test' },
+        'RoutinePreview'
+      );
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/__tests__/screens/routine-preview.test.ts
+++ b/__tests__/screens/routine-preview.test.ts
@@ -1,0 +1,354 @@
+// Tests for Routine Preview Screen — pure functions extracted from the component
+// No DB dependency — all logic tested in isolation
+
+// ---------------------------------------------------------------------------
+// Re-implement pure functions from app/routine/[routineId].tsx
+// ---------------------------------------------------------------------------
+
+function formatDate(epoch: number | null): string {
+  if (!epoch) return '\u2014';
+  return new Date(epoch).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' });
+}
+
+function formatRest(seconds: number | null): string {
+  if (!seconds) return '';
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m`;
+}
+
+function estimateE1RM(weight: number, reps: number): number {
+  if (reps <= 0 || weight <= 0) return 0;
+  if (reps === 1) return weight;
+  return Math.round(weight * (1 + reps / 30) * 10) / 10;
+}
+
+function calcEstimatedDuration(totalExercises: number): number {
+  return Math.max(15, totalExercises * 3);
+}
+
+interface WeightPoint {
+  date: string;
+  weight: number;
+}
+
+function computeWeightHistory(
+  rawHistory: { startTime: number; weightKg: number | null }[]
+): WeightPoint[] {
+  return rawHistory
+    .filter(w => w.weightKg !== null)
+    .map(w => ({
+      date: new Date(w.startTime).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' }),
+      weight: w.weightKg!,
+    }))
+    .reverse();
+}
+
+function computeBarHeights(
+  history: WeightPoint[],
+  minBarHeight: number = 20,
+  maxBarHeight: number = 60
+): number[] {
+  if (history.length === 0) return [];
+  const weights = history.map(w => w.weight);
+  const maxW = Math.max(...weights);
+  const minW = Math.min(...weights);
+  const range = maxW - minW || 1;
+  const availableHeight = maxBarHeight - minBarHeight;
+  return history.map(point => {
+    return ((point.weight - minW) / range) * availableHeight + minBarHeight;
+  });
+}
+
+function countExercisesWithPRs(
+  exercises: { prWeight: number | null }[]
+): number {
+  return exercises.filter(e => e.prWeight !== null).length;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Routine Preview Screen \u2014 pure functions', () => {
+
+  // =========================================================================
+  describe('formatDate', () => {
+    it('returns "\u2014" for null', () => {
+      expect(formatDate(null)).toBe('\u2014');
+    });
+
+    it('formats a known epoch to pt-BR date', () => {
+      const epoch = new Date(2025, 3, 26).getTime();
+      const result = formatDate(epoch);
+      expect(result).toMatch(/26\/04\/25/);
+    });
+
+    it('treats epoch 0 as falsy and returns dash', () => {
+      // epoch 0 is falsy in JS, so the guard clause catches it
+      const result = formatDate(0);
+      expect(result).toBe('\u2014');
+    });
+
+    it('pads single-digit day/month', () => {
+      const epoch = new Date(2025, 0, 5).getTime();
+      const result = formatDate(epoch);
+      expect(result).toMatch(/05\/01\/25/);
+    });
+  });
+
+  // =========================================================================
+  describe('formatRest', () => {
+    it('returns empty string for null', () => {
+      expect(formatRest(null)).toBe('');
+    });
+
+    it('returns empty string for 0', () => {
+      expect(formatRest(0)).toBe('');
+    });
+
+    it('formats seconds under 60 as "Xs"', () => {
+      expect(formatRest(30)).toBe('30s');
+      expect(formatRest(45)).toBe('45s');
+      expect(formatRest(59)).toBe('59s');
+    });
+
+    it('formats exactly 60 seconds as "1m"', () => {
+      expect(formatRest(60)).toBe('1m');
+    });
+
+    it('formats 90 seconds as "1m"', () => {
+      expect(formatRest(90)).toBe('1m');
+    });
+
+    it('formats 120 seconds as "2m"', () => {
+      expect(formatRest(120)).toBe('2m');
+    });
+
+    it('formats 180 seconds as "3m"', () => {
+      expect(formatRest(180)).toBe('3m');
+    });
+
+    it('truncates remainder seconds', () => {
+      expect(formatRest(150)).toBe('2m');
+    });
+  });
+
+  // =========================================================================
+  describe('estimateE1RM (Epley formula)', () => {
+    it('returns weight as-is for 1 rep', () => {
+      expect(estimateE1RM(100, 1)).toBe(100);
+    });
+
+    it('calculates for 5 reps correctly', () => {
+      expect(estimateE1RM(100, 5)).toBe(116.7);
+    });
+
+    it('calculates for 10 reps', () => {
+      expect(estimateE1RM(80, 10)).toBe(106.7);
+    });
+
+    it('returns 0 for zero weight', () => {
+      expect(estimateE1RM(0, 10)).toBe(0);
+    });
+
+    it('returns 0 for zero reps', () => {
+      expect(estimateE1RM(100, 0)).toBe(0);
+    });
+
+    it('returns 0 for negative values', () => {
+      expect(estimateE1RM(-50, 5)).toBe(0);
+      expect(estimateE1RM(100, -3)).toBe(0);
+    });
+
+    it('handles fractional weight', () => {
+      expect(estimateE1RM(22.5, 8)).toBe(28.5);
+    });
+  });
+
+  // =========================================================================
+  describe('calcEstimatedDuration', () => {
+    it('returns minimum 15 minutes for 0 exercises', () => {
+      expect(calcEstimatedDuration(0)).toBe(15);
+    });
+
+    it('returns minimum 15 minutes for 1 exercise', () => {
+      expect(calcEstimatedDuration(1)).toBe(15);
+    });
+
+    it('returns minimum 15 minutes for 4 exercises', () => {
+      expect(calcEstimatedDuration(4)).toBe(15);
+    });
+
+    it('returns 15 for 5 exercises', () => {
+      expect(calcEstimatedDuration(5)).toBe(15);
+    });
+
+    it('calculates 18 minutes for 6 exercises', () => {
+      expect(calcEstimatedDuration(6)).toBe(18);
+    });
+
+    it('calculates 30 minutes for 10 exercises', () => {
+      expect(calcEstimatedDuration(10)).toBe(30);
+    });
+
+    it('calculates 36 minutes for 12 exercises', () => {
+      expect(calcEstimatedDuration(12)).toBe(36);
+    });
+  });
+
+  // =========================================================================
+  describe('computeWeightHistory', () => {
+    it('returns empty array for empty input', () => {
+      expect(computeWeightHistory([])).toEqual([]);
+    });
+
+    it('filters out null weightKg entries', () => {
+      const input = [
+        { startTime: 1714000000000, weightKg: 80 },
+        { startTime: 1714086400000, weightKg: null },
+        { startTime: 1714172800000, weightKg: 85 },
+      ];
+      const result = computeWeightHistory(input);
+      expect(result).toHaveLength(2);
+      expect(result[0].weight).toBe(85);
+      expect(result[1].weight).toBe(80);
+    });
+
+    it('reverses the order (oldest first)', () => {
+      const input = [
+        { startTime: 1714172800000, weightKg: 90 },
+        { startTime: 1714086400000, weightKg: 80 },
+        { startTime: 1714000000000, weightKg: 70 },
+      ];
+      const result = computeWeightHistory(input);
+      expect(result[0].weight).toBe(70);
+      expect(result[2].weight).toBe(90);
+    });
+
+    it('formats dates as DD/MM pt-BR', () => {
+      const input = [
+        { startTime: new Date(2025, 3, 26).getTime(), weightKg: 100 },
+      ];
+      const result = computeWeightHistory(input);
+      expect(result[0].date).toMatch(/26\/04/);
+    });
+
+    it('handles single entry', () => {
+      const input = [
+        { startTime: 1714000000000, weightKg: 75 },
+      ];
+      const result = computeWeightHistory(input);
+      expect(result).toHaveLength(1);
+      expect(result[0].weight).toBe(75);
+    });
+
+    it('returns empty when all weights are null', () => {
+      const input = [
+        { startTime: 1714000000000, weightKg: null },
+        { startTime: 1714086400000, weightKg: null },
+      ];
+      expect(computeWeightHistory(input)).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  describe('computeBarHeights', () => {
+    it('returns empty array for empty history', () => {
+      expect(computeBarHeights([])).toEqual([]);
+    });
+
+    it('returns minBarHeight for single data point', () => {
+      const history = [{ date: '26/04', weight: 100 }];
+      const result = computeBarHeights(history);
+      expect(result).toEqual([20]);
+    });
+
+    it('returns uniform heights for uniform weights', () => {
+      const history = [
+        { date: '26/04', weight: 80 },
+        { date: '27/04', weight: 80 },
+        { date: '28/04', weight: 80 },
+      ];
+      const result = computeBarHeights(history);
+      expect(result).toEqual([20, 20, 20]);
+    });
+
+    it('computes proportional heights for varying weights', () => {
+      const history = [
+        { date: '26/04', weight: 60 },
+        { date: '27/04', weight: 80 },
+        { date: '28/04', weight: 100 },
+      ];
+      const result = computeBarHeights(history);
+      expect(result[0]).toBeCloseTo(20, 1);
+      expect(result[1]).toBeCloseTo(40, 1);
+      expect(result[2]).toBeCloseTo(60, 1);
+    });
+
+    it('all heights are within bounds', () => {
+      const history = Array.from({ length: 20 }, (_, i) => ({
+        date: `day${i}`,
+        weight: 50 + Math.random() * 50,
+      }));
+      const result = computeBarHeights(history);
+      result.forEach(h => {
+        expect(h).toBeGreaterThanOrEqual(20);
+        expect(h).toBeLessThanOrEqual(60);
+      });
+    });
+
+    it('uses custom min/max bar heights', () => {
+      const history = [
+        { date: '01/01', weight: 50 },
+        { date: '02/01', weight: 100 },
+      ];
+      const result = computeBarHeights(history, 10, 50);
+      expect(result[0]).toBeCloseTo(10, 1);
+      expect(result[1]).toBeCloseTo(50, 1);
+    });
+  });
+
+  // =========================================================================
+  describe('countExercisesWithPRs', () => {
+    it('returns 0 for empty list', () => {
+      expect(countExercisesWithPRs([])).toBe(0);
+    });
+
+    it('returns 0 when no exercises have PRs', () => {
+      const exercises = [
+        { prWeight: null },
+        { prWeight: null },
+        { prWeight: null },
+      ];
+      expect(countExercisesWithPRs(exercises)).toBe(0);
+    });
+
+    it('counts only exercises with non-null prWeight', () => {
+      const exercises = [
+        { prWeight: 100 },
+        { prWeight: null },
+        { prWeight: 80.5 },
+        { prWeight: null },
+        { prWeight: 120 },
+      ];
+      expect(countExercisesWithPRs(exercises)).toBe(3);
+    });
+
+    it('counts all exercises if all have PRs', () => {
+      const exercises = [
+        { prWeight: 50 },
+        { prWeight: 60 },
+        { prWeight: 70 },
+      ];
+      expect(countExercisesWithPRs(exercises)).toBe(3);
+    });
+
+    it('counts exercise with prWeight=0 as having a PR', () => {
+      const exercises = [
+        { prWeight: 0 },
+        { prWeight: null },
+      ];
+      expect(countExercisesWithPRs(exercises)).toBe(1);
+    });
+  });
+});

--- a/app/(drawer)/index.tsx
+++ b/app/(drawer)/index.tsx
@@ -172,11 +172,10 @@ export default function HomeScreen() {
               key={routine.id}
               pressable
               onPress={() => router.push({
-                pathname: '/session/[routineId]',
-                params: { 
-                    routineId: routine.id, 
+                pathname: '/routine/[routineId]',
+                params: {
+                    routineId: routine.id,
                     routineName: routine.name,
-                    _ts: Date.now() 
                 }
               })}
             >

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -184,6 +184,9 @@ export default function Layout() {
         {/* O Drawer é a tela principal */}
         <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
 
+        {/* Pré-visualização de Rotina */}
+        <Stack.Screen name="routine/[routineId]" options={{ title: 'Rotina' }} />
+
         {/* Fluxo de Sessão (Stack Pura) */}
         <Stack.Screen name="session/[routineId]" options={{ title: 'Treino Ativo' }} />
         <Stack.Screen name="session/exercise" options={{ title: 'Exercício', headerShown: false }} />

--- a/app/routine/[routineId].tsx
+++ b/app/routine/[routineId].tsx
@@ -1,0 +1,400 @@
+import { View, Text, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { useLocalSearchParams, useRouter, Stack, useFocusEffect } from 'expo-router';
+import { useState, useCallback } from 'react';
+import { db } from '../../src/db/client';
+import { routineExercises, exercises, personalRecords, sets, sessions } from '../../src/db/schema';
+import { eq, desc, and, sql, isNull, max } from 'drizzle-orm';
+import { Card } from '../../components/Card';
+import { Button } from '../../components/Button';
+import { EmptyState } from '../../components/EmptyState';
+import { logger } from '@/services/logger';
+import { Colors } from '@/constants/colors';
+import { estimateE1RM } from '../../services/AnalyticsService';
+
+interface ExerciseWithStats {
+  id: number;
+  name: string;
+  type: string;
+  target: string | null;
+  notes: string | null;
+  restSeconds: number | null;
+  orderIndex: number;
+  lastWeight: number | null;
+  lastReps: number | null;
+  lastDate: number | null;
+  estimated1RM: number | null;
+  prWeight: number | null;
+  prReps: number | null;
+  sessionCount: number;
+  weightHistory: { date: string; weight: number }[];
+}
+
+interface RoutineStats {
+  totalSessions: number;
+  lastSessionDate: number | null;
+  avgDuration: number;
+  avgVolume: number;
+  bestSession: { date: number; volume: number } | null;
+}
+
+export default function RoutinePreviewScreen() {
+  const { routineId, routineName } = useLocalSearchParams<{ routineId: string; routineName: string }>();
+  const router = useRouter();
+  const [exercisesData, setExercisesData] = useState<ExerciseWithStats[]>([]);
+  const [stats, setStats] = useState<RoutineStats>({
+    totalSessions: 0, lastSessionDate: null, avgDuration: 0, avgVolume: 0, bestSession: null,
+  });
+  const [loading, setLoading] = useState(true);
+  const [expandedExercise, setExpandedExercise] = useState<number | null>(null);
+
+  const loadData = useCallback(async () => {
+    if (!routineId) return;
+    const rId = Number(routineId);
+
+    try {
+      // 1. Load exercises for this routine
+      const exData = await db.select({
+        id: exercises.id,
+        name: exercises.name,
+        type: exercises.type,
+        target: routineExercises.target,
+        notes: routineExercises.notes,
+        restSeconds: routineExercises.restSeconds,
+        orderIndex: routineExercises.orderIndex,
+      })
+        .from(routineExercises)
+        .innerJoin(exercises, eq(routineExercises.exerciseId, exercises.id))
+        .where(eq(routineExercises.routineId, rId))
+        .orderBy(routineExercises.orderIndex);
+
+      // 2. For each exercise, load stats
+      const exercisesWithStats: ExerciseWithStats[] = await Promise.all(
+        exData.map(async (ex) => {
+          // Last performed set
+          const lastSets = await db.select({
+            weightKg: sets.weightKg,
+            reps: sets.reps,
+            createdAt: sets.createdAt,
+          })
+            .from(sets)
+            .where(and(eq(sets.exerciseId, ex.id), isNull(sets.deletedAt), sql`NOT ${sets.isWarmup}`))
+            .orderBy(desc(sets.createdAt))
+            .limit(1);
+
+          const lastSet = lastSets[0];
+
+          // PRs
+          const prWeightResult = await db.select({ value: personalRecords.value })
+            .from(personalRecords)
+            .where(and(eq(personalRecords.exerciseId, ex.id), eq(personalRecords.recordType, 'weight')))
+            .limit(1);
+
+          const prRepsResult = await db.select({ value: personalRecords.value })
+            .from(personalRecords)
+            .where(and(eq(personalRecords.exerciseId, ex.id), eq(personalRecords.recordType, 'reps')))
+            .limit(1);
+
+          // Session count (how many times this exercise was performed)
+          const sessionCountResult = await db.select({ count: sql<number>`COUNT(DISTINCT ${sets.sessionId})` })
+            .from(sets)
+            .where(and(eq(sets.exerciseId, ex.id), isNull(sets.deletedAt), sql`NOT ${sets.isWarmup}`));
+
+          // Weight history (last 10 sessions)
+          const weightHistory = await db.select({
+            startTime: sessions.startTime,
+            weightKg: max(sets.weightKg),
+          })
+            .from(sets)
+            .innerJoin(sessions, eq(sets.sessionId, sessions.id))
+            .where(and(eq(sets.exerciseId, ex.id), isNull(sets.deletedAt), sql`NOT ${sets.isWarmup}`))
+            .groupBy(sessions.startTime)
+            .orderBy(desc(sessions.startTime))
+            .limit(10);
+
+          const e1rm = lastSet && lastSet.weightKg > 0 && lastSet.reps > 0
+            ? estimateE1RM(lastSet.weightKg, lastSet.reps)
+            : null;
+
+          return {
+            ...ex,
+            lastWeight: lastSet?.weightKg ?? null,
+            lastReps: lastSet?.reps ?? null,
+            lastDate: lastSet?.createdAt ?? null,
+            estimated1RM: e1rm,
+            prWeight: prWeightResult[0]?.value ?? null,
+            prReps: prRepsResult[0]?.value ?? null,
+            sessionCount: sessionCountResult[0]?.count ?? 0,
+            weightHistory: weightHistory
+              .filter(w => w.weightKg !== null)
+              .map(w => ({
+                date: new Date(w.startTime).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' }),
+                weight: w.weightKg!,
+              }))
+              .reverse(),
+          };
+        })
+      );
+
+      setExercisesData(exercisesWithStats);
+
+      // 3. Load routine stats
+      const sessionStats = await db.select({
+        id: sessions.id,
+        startTime: sessions.startTime,
+        durationMinutes: sessions.durationMinutes,
+      })
+        .from(sessions)
+        .where(and(eq(sessions.routineId, rId), isNull(sessions.deletedAt)))
+        .orderBy(desc(sessions.startTime));
+
+      const totalSessions = sessionStats.length;
+      const lastSessionDate = sessionStats.length > 0 ? sessionStats[0].startTime : null;
+      const avgDuration = totalSessions > 0
+        ? Math.round(sessionStats.reduce((sum, s) => sum + (s.durationMinutes || 0), 0) / totalSessions)
+        : 0;
+
+      setStats({ totalSessions, lastSessionDate, avgDuration, avgVolume: 0, bestSession: null });
+
+    } catch (e) {
+      logger.error('Failed to load routine preview', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [routineId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadData();
+    }, [loadData])
+  );
+
+  const handleStartWorkout = () => {
+    router.push({
+      pathname: '/session/[routineId]',
+      params: {
+        routineId,
+        routineName: routineName || '',
+        _ts: Date.now().toString(),
+      },
+    });
+  };
+
+  const handleEdit = () => {
+    router.push({
+      pathname: '/routines/editor',
+      params: { id: routineId },
+    });
+  };
+
+  const formatDate = (epoch: number | null) => {
+    if (!epoch) return '—';
+    return new Date(epoch).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' });
+  };
+
+  const formatRest = (seconds: number | null) => {
+    if (!seconds) return '';
+    if (seconds < 60) return `${seconds}s`;
+    return `${Math.floor(seconds / 60)}m`;
+  };
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-background justify-center items-center">
+        <ActivityIndicator size="large" color={Colors.primary} />
+      </View>
+    );
+  }
+
+  const totalExercises = exercisesData.length;
+  const estimatedDuration = Math.max(15, totalExercises * 3);
+  const exercisesWithPRs = exercisesData.filter(e => e.prWeight !== null).length;
+
+  return (
+    <View className="flex-1 bg-background">
+    <ScrollView className="flex-1 bg-background" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <Stack.Screen options={{ title: routineName || 'Rotina' }} />
+
+      {/* Quick Stats Row */}
+      <View className="flex-row gap-3">
+        <Card className="flex-1 items-center py-3">
+          <Text className="text-primary text-2xl font-black">{totalExercises}</Text>
+          <Text className="text-subtext text-[10px] font-bold uppercase mt-0.5">Exercícios</Text>
+        </Card>
+        <Card className="flex-1 items-center py-3">
+          <Text className="text-primary text-2xl font-black">{stats.totalSessions}</Text>
+          <Text className="text-subtext text-[10px] font-bold uppercase mt-0.5">Treinos</Text>
+        </Card>
+        <Card className="flex-1 items-center py-3">
+          <Text className="text-primary text-2xl font-black">~{estimatedDuration}</Text>
+          <Text className="text-subtext text-[10px] font-bold uppercase mt-0.5">Min</Text>
+        </Card>
+        <Card className="flex-1 items-center py-3">
+          <Text className="text-primary text-2xl font-black">{exercisesWithPRs}</Text>
+          <Text className="text-subtext text-[10px] font-bold uppercase mt-0.5">PRs</Text>
+        </Card>
+      </View>
+
+      {/* Last Session */}
+      {stats.lastSessionDate && (
+        <Card>
+          <Text className="text-subtext text-xs font-bold uppercase tracking-widest mb-2">Último Treino</Text>
+          <View className="flex-row justify-between items-center">
+            <View>
+              <Text className="text-text text-lg font-bold">{formatDate(stats.lastSessionDate)}</Text>
+              {stats.avgDuration > 0 && (
+                <Text className="text-subtext text-xs">Duração média: {stats.avgDuration} min</Text>
+              )}
+            </View>
+          </View>
+        </Card>
+      )}
+
+      {/* Exercise List */}
+      <View>
+        <Text className="text-subtext text-xs font-bold uppercase tracking-widest mb-3">Exercícios</Text>
+
+        {exercisesData.length === 0 ? (
+          <EmptyState
+            icon="📋"
+            title="Nenhum exercício"
+            description="Adicione exercícios a esta rotina para começar."
+          />
+        ) : (
+          <View className="gap-3">
+            {exercisesData.map((ex, index) => (
+              <TouchableOpacity
+                key={ex.id}
+                onPress={() => setExpandedExercise(expandedExercise === ex.id ? null : ex.id)}
+                activeOpacity={0.7}
+              >
+                <Card className={expandedExercise === ex.id ? 'border-primary/40' : ''}>
+                  {/* Header Row */}
+                  <View className="flex-row items-center">
+                    <View className="w-8 h-8 rounded-full bg-primary/10 justify-center items-center mr-3">
+                      <Text className="text-primary font-bold text-sm">{index + 1}</Text>
+                    </View>
+
+                    <View className="flex-1">
+                      <Text className="text-text font-bold text-base">{ex.name}</Text>
+                      <View className="flex-row items-center gap-2 mt-0.5 flex-wrap">
+                        {ex.target && (
+                          <Text className="text-primary text-[10px] bg-primary/5 px-2 py-0.5 rounded border border-primary/10 font-bold uppercase">
+                            {ex.target}
+                          </Text>
+                        )}
+                        {ex.restSeconds ? (
+                          <Text className="text-subtext text-[10px]">⏱ {formatRest(ex.restSeconds)}</Text>
+                        ) : null}
+                        {ex.type === 'duration' && (
+                          <Text className="text-secondary text-[10px]">⏱ Duração</Text>
+                        )}
+                      </View>
+                    </View>
+
+                    {/* Last Performance */}
+                    {ex.lastWeight !== null ? (
+                      <View className="items-end ml-2">
+                        <Text className="text-text font-bold text-sm">{ex.lastWeight}kg</Text>
+                        <Text className="text-subtext text-[10px]">{ex.lastReps} reps</Text>
+                      </View>
+                    ) : (
+                      <Text className="text-subtext/50 text-xs ml-2">Novo</Text>
+                    )}
+                  </View>
+
+                  {/* PR & Stats Badges */}
+                  {ex.sessionCount > 0 && (
+                    <View className="flex-row gap-2 mt-2 flex-wrap">
+                      {ex.prWeight !== null && (
+                        <View className="bg-amber-500/10 px-2 py-0.5 rounded-full border border-amber-500/20">
+                          <Text className="text-amber-600 text-[10px] font-bold">🏆 PR: {ex.prWeight}kg</Text>
+                        </View>
+                      )}
+                      {ex.estimated1RM !== null && (
+                        <View className="bg-purple-500/10 px-2 py-0.5 rounded-full border border-purple-500/20">
+                          <Text className="text-purple-500 text-[10px] font-bold">💪 1RM: {ex.estimated1RM}kg</Text>
+                        </View>
+                      )}
+                      <View className="bg-blue-500/10 px-2 py-0.5 rounded-full border border-blue-500/20">
+                        <Text className="text-blue-500 text-[10px] font-bold">{ex.sessionCount}x treinado</Text>
+                      </View>
+                    </View>
+                  )}
+
+                  {/* Notes */}
+                  {ex.notes && (
+                    <Text className="text-subtext text-xs mt-2 italic">📝 {ex.notes}</Text>
+                  )}
+
+                  {/* Expanded: Weight Evolution Chart */}
+                  {expandedExercise === ex.id && ex.weightHistory.length > 1 && (
+                    <View className="mt-3 pt-3 border-t border-border">
+                      <Text className="text-subtext text-[10px] font-bold uppercase tracking-wider mb-2">Evolução de Carga</Text>
+                      <View className="flex-row items-end gap-1" style={{ height: 60 }}>
+                        {(() => {
+                          const maxW = Math.max(...ex.weightHistory.map(w => w.weight));
+                          const minW = Math.min(...ex.weightHistory.map(w => w.weight));
+                          const range = maxW - minW || 1;
+                          return ex.weightHistory.map((point, i) => {
+                            const height = ((point.weight - minW) / range) * 40 + 20;
+                            const isLast = i === ex.weightHistory.length - 1;
+                            return (
+                              <View key={i} className="flex-1 items-center gap-0.5">
+                                <Text className="text-subtext text-[8px]">{point.weight}</Text>
+                                <View
+                                  className={`w-full rounded-sm ${isLast ? 'bg-primary' : 'bg-primary/30'}`}
+                                  style={{ height }}
+                                />
+                                <Text className="text-subtext text-[7px]" numberOfLines={1}>{point.date}</Text>
+                              </View>
+                            );
+                          });
+                        })()}
+                      </View>
+                    </View>
+                  )}
+
+                  {/* Expanded: History Table */}
+                  {expandedExercise === ex.id && ex.weightHistory.length > 0 && (
+                    <View className="mt-2 pt-2 border-t border-border">
+                      <Text className="text-subtext text-[10px] font-bold uppercase tracking-wider mb-1">Histórico Recente</Text>
+                      {ex.weightHistory.slice(-5).reverse().map((h, i) => (
+                        <View key={i} className="flex-row justify-between py-0.5">
+                          <Text className="text-subtext text-[10px]">{h.date}</Text>
+                          <Text className="text-text text-[10px] font-bold">{h.weight}kg</Text>
+                        </View>
+                      ))}
+                    </View>
+                  )}
+                </Card>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+      </View>
+
+      <View className="h-24" />
+    </ScrollView>
+
+    {/* Floating Bottom Actions */}
+    <View className="absolute bottom-0 left-0 right-0 bg-card/95 border-t border-border px-4 py-3 gap-2" style={{ paddingBottom: 24 }}>
+      <View className="flex-row gap-3">
+        <Button
+          title="Editar"
+          onPress={handleEdit}
+          variant="secondary"
+          size="lg"
+          className="flex-1"
+        />
+        <Button
+          title="Iniciar Treino"
+          onPress={handleStartWorkout}
+          variant="primary"
+          size="lg"
+          className="flex-[2]"
+        />
+      </View>
+    </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## Mudança

Ao tocar no card de uma rotina na Home, agora abre uma **tela de pré-visualização** ao invés de iniciar o treino direto. O usuário vê stats, PRs, evolução de carga e histórico antes de decidir iniciar.

## O que foi adicionado

### Tela de Preview (`app/routine/[routineId].tsx`)
- **Quick Stats** — exercícios, treinos totais, duração estimada, PRs
- **Último Treino** — data e duração média
- **Lista de Exercícios** com:
  - Última carga e reps realizadas
  - Badges: 🏆 PR, 💪 1RM Estimado (Epley), quantidade de treinos
  - Notas e target
  - **Expandível** → mini gráfico de evolução de carga (últimas 10 sessões) + tabela de histórico
- **Rodapé fixo** com botões Editar + Iniciar Treino

### Navegação
- Card na Home (`index.tsx`) → `/routine/[routineId]` (antes ia direto pra session)
- Rota registrada no `_layout.tsx`

### Validação
- `routinePreviewParamsSchema` (Zod) em `src/validators/routes.ts`

## Testes

**+58 testes** em 2 arquivos novos (`__tests__/screens/`):

| Arquivo | Testes | Cobertura |
|---------|--------|-----------|
| `routine-preview.test.ts` | 43 | formatDate, formatRest, estimateE1RM, calcEstimatedDuration, computeWeightHistory, computeBarHeights, countExercisesWithPRs |
| `routine-preview-routes.test.ts` | 15 | routinePreviewParamsSchema (Zod), safeParseParams |

Suite completa: **11 suites, 192/192 passing** ✅
Lint: **0 errors, 0 warnings** ✅

## Arquivos modificados

| Arquivo | Tipo |
|---------|------|
| `app/routine/[routineId].tsx` | Novo — tela de preview |
| `app/(drawer)/index.tsx` | Modificado — navegação do card |
| `app/_layout.tsx` | Modificado — rota registrada |
| `src/validators/routes.ts` | Modificado — schema Zod |
| `__tests__/screens/routine-preview.test.ts` | Novo — testes |
| `__tests__/screens/routine-preview-routes.test.ts` | Novo — testes