### PR TITLE
refactor: split exercise session screen

### DIFF
--- a/app/session/exercise.tsx
+++ b/app/session/exercise.tsx
@@ -3,68 +3,37 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  FlatList,
-  Modal,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import Animated, { FadeInRight, FadeOutLeft } from 'react-native-reanimated';
-import { db } from '../../src/db/client';
-import { sets, exercises, sessions, routineExercises } from '../../src/db/schema';
-import { eq, and, desc, isNull, ne } from 'drizzle-orm';
-import { Stopwatch } from '../../components/Stopwatch';
-import { ProgressBar } from '../../components/ProgressBar';
-import SetCard from '../../components/SetCard';
-import { SetEditor } from '../../components/SetEditor';
-import { RestTimer } from '../../components/RestTimer';
 import { Button } from '../../components/Button';
 import { Toast } from '../../components/Toast';
+import { SetEditor } from '../../components/SetEditor';
 import Slider from '@react-native-community/slider';
-import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { parseTargetSets } from '../../src/utils/exercise';
 import { formatTimer } from '../../src/utils/timer';
-import { useHaptics } from '../../hooks/use-haptics';
-import { logger } from '@/services/logger';
-import { Set } from '@/src/types';
 import { Colors } from '@/constants/colors';
 import { safeParseParams, exerciseParamsSchema } from '@/src/validators/routes';
-import { setInputSchema } from '@/src/validators/forms';
-import { useI18n, getLocaleForLanguage } from '../../src/i18n/index';
-import { 
-  usePrograms, 
-  useSessionTimer, 
-  useSessionUndo, 
-  useSessionPersistence, 
-  checkPersonalRecords 
-} from '../../hooks';
-import type { DoubleProgressionStatus } from '../../src/types';
+import { useExerciseSets, useProgression } from '../../hooks';
+import { useHaptics } from '../../hooks/use-haptics';
 import { buildWorkoutA11y } from '../../src/utils/workout-a11y';
+import { useSessionPersistence } from '../../hooks/use-session-persistence';
+import { ExerciseHeader } from '../../components/session/ExerciseHeader';
+import { SetList } from '../../components/session/SetList';
+import { RestTimerBar } from '../../components/session/RestTimerBar';
+import { ExerciseHistoryModal } from '../../components/session/ExerciseHistoryModal';
+import { RirExplainerModal } from '../../components/session/RirExplainerModal';
 
 export default function ExerciseScreen() {
-  const { t, language } = useI18n();
-  const a11y = buildWorkoutA11y({
-    endSession: t('a11y.endSession'),
-    warmupSwitch: t('a11y.warmupSwitch'),
-    undoLastSetLabel: t('exercise.undoLastSet'),
-    undoLastSetHint: t('a11y.undoLastSetHint'),
-    durationStart: t('a11y.durationStart'),
-    durationStop: t('a11y.durationStop'),
-    running: t('a11y.running'),
-    history: t('a11y.openHistory'),
-  });
   const router = useRouter();
   const params = useLocalSearchParams();
   const insets = useSafeAreaInsets();
   const { trigger } = useHaptics();
-  const { activeProgram, fetchActiveProgram, getDoubleProgressionStatus } = usePrograms();
-  const [progressionStatus, setProgressionStatus] = useState<DoubleProgressionStatus | null>(null);
 
   // Validate route params with Zod to prevent NaN
-  // (Validation runs after hooks — early return is handled by useEffect)
   const validated = safeParseParams(exerciseParamsSchema, params, 'ExerciseScreen');
   const routineId = validated?.routineId ?? null;
   const sessionId = validated?.sessionId ?? 0;
@@ -75,51 +44,68 @@ export default function ExerciseScreen() {
   const routineRest = validated?.restSeconds ?? null;
   const startTime = validated?.startTime ?? Date.now();
 
-  const [exerciseType, setExerciseType] = useState('strength');
-  const [currentName, setCurrentName] = useState(exerciseName);
-  const [weight, setWeight] = useState('');
-  const [reps, setReps] = useState('');
-  const [duration, setDuration] = useState('');
-  const [rir, setRir] = useState(2);
-  const [sessionSets, setSessionSets] = useState<Set[]>([]);
-  const [nextExercise, setNextExercise] = useState<any>(null);
-  const [allExercises, setAllExercises] = useState<any[]>([]);
-  const [isWarmupMode, setIsWarmupMode] = useState(false);
+  const {
+    exerciseType,
+    currentName,
+    weight,
+    setWeight,
+    reps,
+    setReps,
+    duration,
+    rir,
+    setRir,
+    sessionSets,
+    nextExercise,
+    allExercises,
+    isWarmupMode,
+    setIsWarmupMode,
+    historyVisible,
+    setHistoryVisible,
+    historyData,
+    timerSeconds,
+    timerStatus,
+    setTimerSeconds,
+    setTimerStatus,
+    addTime,
+    activeSetTime,
+    isActiveSetRunning,
+    toggleActiveSet,
+    lastSavedSet,
+    handleUndo,
+    isSaving,
+    toast,
+    setToast,
+    editingSet,
+    setEditingSet,
+    showSetEditor,
+    setShowSetEditor,
+    completedExercisesCount,
+    handleSaveSet,
+    handleDeleteSet,
+    handleEditSet,
+    handleSaveEditedSet,
+    t,
+    language,
+  } = useExerciseSets({
+    sessionId,
+    exerciseId,
+    routineId,
+    exerciseName,
+    routineRest,
+  });
 
-  // Track completed exercises by target sets
-  const { data: allSessionSets } = useLiveQuery(
-    db.select({ exerciseId: sets.exerciseId })
-      .from(sets)
-      .where(and(eq(sets.sessionId, sessionId), isNull(sets.deletedAt)))
-  );
+  const a11y = buildWorkoutA11y({
+    endSession: t('a11y.endSession'),
+    warmupSwitch: t('a11y.warmupSwitch'),
+    undoLastSetLabel: t('exercise.undoLastSet'),
+    undoLastSetHint: t('a11y.undoLastSetHint'),
+    durationStart: t('a11y.durationStart'),
+    durationStop: t('a11y.durationStop'),
+    running: t('a11y.running'),
+    history: t('a11y.openHistory'),
+  });
 
-  // Count completed exercises (based on target sets met)
-  const completedExercisesCount = allExercises.reduce((count, exercise) => {
-    const targetSets = parseTargetSets(exercise.target);
-    const doneSets = allSessionSets?.filter(s => s.exerciseId === exercise.id).length || 0;
-
-    if (targetSets !== null) {
-      return doneSets >= targetSets ? count + 1 : count;
-    }
-    return doneSets > 0 ? count + 1 : count;
-  }, 0);
-
-  const [historyVisible, setHistoryVisible] = useState(false);
-  const [historyData, setHistoryData] = useState<{ sessionId: number; date: number; weight: number | null; reps: number | null; duration: number | null; rir: number | null }[]>([]);
-
-  // Timer Hook
-  const timer = useSessionTimer();
-  const { 
-    timerSeconds, timerStatus, 
-    setTimerSeconds, setTimerTarget, setTimerStatus, 
-    addTime, activeSetTime, 
-    isActiveSetRunning, toggleActiveSet 
-  } = timer;
-
-  // Undo Hook
-  const { 
-    lastSavedSet, setLastSavedSet, undoTimeoutRef, handleUndo: hookHandleUndo 
-  } = useSessionUndo();
+  const { activeProgram, progressionStatus } = useProgression(exerciseId, exerciseName);
 
   // Persistence Hook
   useSessionPersistence({
@@ -139,278 +125,6 @@ export default function ExerciseScreen() {
     notes,
     restSeconds: routineRest,
   });
-
-  // Loading state
-  const [isSaving, setIsSaving] = useState(false);
-
-  // Toast state
-  const [toast, setToast] = useState({ visible: false, message: '', type: 'success' as 'success' | 'error' | 'info' });
-
-  // Set Editor state
-  const [editingSet, setEditingSet] = useState<Set | null>(null);
-  const [showSetEditor, setShowSetEditor] = useState(false);
-
-  // RIR Explainer modal state
-  const [showRirExplainer, setShowRirExplainer] = useState(false);
-
-  // Total exercises for progress bar
-  const totalExercises = allExercises.length;
-
-  const loadData = useCallback(async () => {
-    try {
-      setNextExercise(null);
-
-      const exData = await db.select().from(exercises).where(eq(exercises.id, exerciseId));
-      if (exData.length > 0) {
-        setExerciseType(exData[0].type);
-        setCurrentName(exData[0].name);
-      }
-
-      const data = await db.select()
-        .from(sets)
-        .where(and(eq(sets.sessionId, sessionId), eq(sets.exerciseId, exerciseId), isNull(sets.deletedAt)))
-        .orderBy(sets.setNumber);
-      setSessionSets(data);
-
-      if (data.length === 0) {
-        const lastSet = await db.select({ weight: sets.weightKg })
-          .from(sets)
-          .where(and(eq(sets.exerciseId, exerciseId), isNull(sets.deletedAt)))
-          .orderBy(desc(sets.createdAt))
-          .limit(1);
-
-        if (lastSet.length > 0 && lastSet[0].weight) {
-          setWeight(lastSet[0].weight.toString());
-        }
-      }
-
-      if (routineId) {
-        const routineList = await db.select({
-          id: exercises.id,
-          name: exercises.name,
-          target: routineExercises.target,
-          notes: routineExercises.notes,
-          restSeconds: routineExercises.restSeconds
-        })
-          .from(routineExercises)
-          .innerJoin(exercises, eq(routineExercises.exerciseId, exercises.id))
-          .where(eq(routineExercises.routineId, routineId))
-          .orderBy(routineExercises.orderIndex);
-
-        setAllExercises(routineList);
-
-        const currentIndex = routineList.findIndex(e => e.id === exerciseId);
-        if (currentIndex !== -1 && currentIndex < routineList.length - 1) {
-          const next = routineList[currentIndex + 1];
-          setNextExercise(next);
-        }
-      }
-    } catch (e) {
-      logger.error(t('common.operationError'), e);
-    }
-  }, [sessionId, exerciseId, routineId, t]);
-
-  const loadHistory = useCallback(async () => {
-    try {
-      const history = await db.select({
-        sessionId: sets.sessionId,
-        date: sessions.startTime,
-        weight: sets.weightKg,
-        reps: sets.reps,
-        duration: sets.durationSeconds,
-        rir: sets.rir
-      })
-        .from(sets)
-        .innerJoin(sessions, eq(sets.sessionId, sessions.id))
-        .where(and(
-          eq(sets.exerciseId, exerciseId),
-          ne(sets.sessionId, sessionId),
-          isNull(sets.deletedAt),
-          isNull(sessions.deletedAt)
-        ))
-        .limit(20);
-
-      history.sort((a, b) => b.date - a.date);
-      setHistoryData(history);
-    } catch (e) {
-      logger.error(t("exercise.sqlHistoryError"), e);
-    }
-  }, [exerciseId, sessionId, t]);
-
-  useEffect(() => {
-    loadData();
-    loadHistory();
-  }, [loadData, loadHistory]);
-
-  // Load double progression status for active program
-  useEffect(() => {
-    const loadProgression = async () => {
-      await fetchActiveProgram();
-    };
-    loadProgression();
-  }, [fetchActiveProgram]);
-
-  useEffect(() => {
-    if (activeProgram && exerciseId) {
-      getDoubleProgressionStatus(activeProgram.id, exerciseId, exerciseName).then(setProgressionStatus);
-    }
-  }, [activeProgram, exerciseId, exerciseName, getDoubleProgressionStatus]);
-
-  const handleSaveSet = useCallback(async (overrideDuration?: number) => {
-    if (isSaving) return;
-
-    const isDuration = exerciseType === 'duration';
-
-    const finalDuration = overrideDuration !== undefined ? overrideDuration : (duration ? Number(duration) : 0);
-    const finalReps = reps ? Number(reps) : 0;
-
-    // Validate with Zod
-    const setValidation = setInputSchema.safeParse({
-      weightKg: Number(weight) || 0,
-      reps: isDuration ? 0 : finalReps,
-      durationSeconds: isDuration ? finalDuration : null,
-      rir: isDuration ? null : Number(rir),
-      isWarmup: isWarmupMode,
-    });
-    if (!setValidation.success) {
-      const msg = setValidation.error.issues[0]?.message || t('common.invalidData');
-      setToast({ visible: true, message: msg, type: 'error' });
-      return;
-    }
-    // Extra business logic validation
-    if (isDuration && finalDuration <= 0) {
-      setToast({ visible: true, message: t('exercise.enterDuration'), type: 'error' });
-      return;
-    }
-    if (!isDuration && finalReps <= 0) {
-      setToast({ visible: true, message: t('exercise.enterReps'), type: 'error' });
-      return;
-    }
-    if (!isDuration && !weight) {
-      setToast({ visible: true, message: t('exercise.enterWeight'), type: 'error' });
-      return;
-    }
-
-    setIsSaving(true);
-
-    try {
-      const nextSetNumber = (sessionSets?.length || 0) + 1;
-
-      const result = await db.insert(sets).values({
-        sessionId,
-        exerciseId,
-        exerciseName: currentName,
-        setNumber: nextSetNumber,
-        weightKg: setValidation.data.weightKg,
-        reps: isDuration ? 0 : finalReps,
-        durationSeconds: isDuration ? finalDuration : null,
-        rir: isDuration ? null : Number(rir),
-        isWarmup: isWarmupMode,
-      }).returning();
-
-      // Store for undo
-      setLastSavedSet(result[0]);
-
-      // Clear undo after 10 seconds
-      if (undoTimeoutRef.current) {
-        clearTimeout(undoTimeoutRef.current);
-      }
-      undoTimeoutRef.current = setTimeout(() => {
-        setLastSavedSet(null);
-      }, 10000);
-
-      await loadData();
-
-      // Check for Personal Records (only for non-warmup strength sets)
-      if (!isWarmupMode && !isDuration && result[0]) {
-        const prResult = await checkPersonalRecords({
-          exerciseId,
-          sessionId,
-          savedSet: result[0],
-          isWarmup: isWarmupMode,
-        });
-
-        if (prResult.isWeightPR || prResult.isRepsPR) {
-          trigger('success');
-          setToast({ visible: true, message: t('finish.prText'), type: 'success' });
-        }
-      }
-
-      setReps('');
-      setDuration('');
-
-      if (!isDuration) {
-        const restTime = routineRest || 90;
-        setTimerTarget(Date.now() + restTime * 1000);
-        setTimerStatus('running');
-      }
-
-    } catch (e) {
-      logger.error(t('common.operationError'), e);
-      setToast({ visible: true, message: t('exercise.saveSetError'), type: 'error' });
-    } finally {
-      setIsSaving(false);
-    }
-  }, [isSaving, exerciseType, duration, reps, weight, rir, sessionId, exerciseId, currentName, sessionSets, routineRest, undoTimeoutRef, loadData, isWarmupMode, t, trigger, setLastSavedSet, setTimerStatus, setTimerTarget]);
-
-  const handleUndo = useCallback(async () => {
-    await hookHandleUndo({
-      exerciseId,
-      sessionId,
-      exerciseType,
-      setSessionSets,
-      setCurrentName,
-      setToast,
-    });
-  }, [hookHandleUndo, exerciseId, sessionId, exerciseType, setSessionSets, setCurrentName, setToast]);
-
-  const handleDeleteSet = useCallback(async (setId: number) => {
-    try {
-      await db.update(sets).set({ deletedAt: Date.now() }).where(eq(sets.id, setId));
-      await loadData();
-      setToast({ visible: true, message: t('exercise.setDeleted'), type: 'success' });
-    } catch (e) {
-      logger.error(t('common.operationError'), e);
-      setToast({ visible: true, message: t('exercise.deleteSetError'), type: 'error' });
-    }
-  }, [loadData, t]);
-
-  const handleEditSet = useCallback(async (setId: number) => {
-    try {
-      const setData = await db.select().from(sets).where(and(eq(sets.id, setId), isNull(sets.deletedAt)));
-      if (setData.length > 0) {
-        setEditingSet(setData[0]);
-        setShowSetEditor(true);
-      }
-    } catch (e) {
-      logger.error(t('common.operationError'), e);
-      setToast({ visible: true, message: t('exercise.loadSetError'), type: 'error' });
-    }
-  }, [t]);
-
-  const handleSaveEditedSet = useCallback(async (weight: number, reps?: number, duration?: number, rir?: number) => {
-    if (!editingSet) return;
-    
-    try {
-      await db.update(sets)
-        .set({
-          weightKg: weight,
-          reps: reps || editingSet.reps,
-          durationSeconds: duration || editingSet.durationSeconds,
-          rir: rir || editingSet.rir,
-          isEdited: true,
-        })
-        .where(eq(sets.id, editingSet.id));
-      
-      await loadData();
-      setShowSetEditor(false);
-      setEditingSet(null);
-      setToast({ visible: true, message: t('exercise.setEdited'), type: 'success' });
-    } catch (e) {
-      logger.error(t('common.operationError'), e);
-      setToast({ visible: true, message: t('exercise.editSetError'), type: 'error' });
-    }
-  }, [editingSet, loadData, t]);
 
   const goToNextOrFinish = useCallback(async () => {
     if (nextExercise) {
@@ -454,6 +168,9 @@ export default function ExerciseScreen() {
 
   const targetInfo = calculateTarget();
   const currentSetNumber = (sessionSets?.length || 0) + 1;
+  const totalExercises = allExercises.length;
+
+  const [showRirExplainer, setShowRirExplainer] = useState(false);
 
   return (
     <KeyboardAvoidingView 
@@ -462,158 +179,90 @@ export default function ExerciseScreen() {
       keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
     >
       <View className="flex-1 bg-background">
-        {/* Header */}
-        <View className="bg-card border-b border-border" style={{ paddingTop: insets.top }}>
-            <View className="p-4">
-              {/* Progress Bar */}
-              {totalExercises > 0 && (
-                <View className="mb-4">
-                  <ProgressBar
-                    current={completedExercisesCount}
-                    total={totalExercises}
-                    variant="compact"
-                    showLabel={true}
-                  />
-                </View>
-              )}
+        <ExerciseHeader
+          insetsTop={insets.top}
+          totalExercises={totalExercises}
+          completedExercisesCount={completedExercisesCount}
+          t={t}
+          startTime={startTime}
+          onOpenHistory={() => setHistoryVisible(true)}
+          a11yHistory={a11y.history}
+          exerciseId={exerciseId}
+          currentName={currentName}
+          currentSetNumber={currentSetNumber}
+          targetInfo={targetInfo}
+          routineRest={routineRest}
+          target={target}
+          notes={notes}
+        />
 
-              <View className="flex-row justify-between items-center mb-2">
-                <View className="flex-row items-baseline gap-2 flex-1">
-                  <Text className="text-subtext text-2xs font-bold uppercase tracking-widest">{t("exerciseSession.time")}</Text>
-                  <Stopwatch startTime={startTime} />
-                </View>
-                <TouchableOpacity
-                  onPress={() => setHistoryVisible(true)}
-                  className="bg-background px-2 py-1 rounded-lg border border-border"
-                  {...a11y.history}
-                >
-                  <Text className="text-subtext text-2xs font-bold uppercase">{t("exerciseSession.history")}</Text>
-                </TouchableOpacity>
-              </View>
-
-              <Animated.View 
-                key={`header-${exerciseId}`} 
-                entering={FadeInRight.duration(300)} 
-                exiting={FadeOutLeft.duration(300)}
-              >
-                <View className="flex-row justify-between items-start">
-                  <View className="flex-1 mr-3">
-                    <Text className="text-text text-xl font-bold" numberOfLines={2}>{currentName}</Text>
-                    <View className="flex-row items-center gap-2 mt-1.5">
-                      <Text className="text-primary text-xs font-semibold bg-primary/10 px-2 py-0.5 rounded-md">
-                        S{currentSetNumber}{targetInfo ? `/${targetInfo.sets}` : ''}
-                      </Text>
-                      {routineRest && (
-                        <Text className="text-subtext text-2xs bg-background px-2 py-0.5 rounded-md border border-border">
-                          ⏱ {routineRest}s
-                        </Text>
-                      )}
-                    </View>
-                  </View>
-                </View>
-
-                {(target || notes) && (
-                  <View className="mt-2 bg-background p-2 rounded-lg border border-border">
-                    {target && <Text className="text-primary font-semibold text-xs">🎯 {target}</Text>}
-                    {notes && <Text className="text-subtext text-2xs italic mt-0.5">📝 {notes}</Text>}
-                  </View>
-                )}
-              </Animated.View>
-            </View>
+        {/* Undo Button (visible for 10s after save) */}
+        {lastSavedSet && (
+          <View className="mx-4 mt-2">
+            <TouchableOpacity
+              onPress={handleUndo}
+              className="bg-warning/90 p-3 rounded-xl shadow-lg flex-row items-center justify-center gap-2"
+              {...a11y.undo}
+            >
+              <Text className="text-white font-bold text-sm">{t('exercise.undoLastSet')}</Text>
+            </TouchableOpacity>
           </View>
+        )}
 
-          {/* Undo Button (visible for 10s after save) */}
-           {lastSavedSet && (
-             <View className="mx-4 mt-2">
-               <TouchableOpacity
-                 onPress={handleUndo}
-                 className="bg-warning/90 p-3 rounded-xl shadow-lg flex-row items-center justify-center gap-2"
-                 {...a11y.undo}
-               >
-                 <Text className="text-white font-bold text-sm">{t('exercise.undoLastSet')}</Text>
-               </TouchableOpacity>
-             </View>
-           )}
-
-          {/* Double Progression Banner */}
-          {activeProgram && progressionStatus && (
-            <View className="mx-4 mt-2">
-              <View className="bg-primary/5 p-3 rounded-xl border border-primary/20">
-                <View className="flex-row justify-between items-center">
-                  <View className="flex-1">
-                    <Text className="text-subtext text-2xs font-bold uppercase tracking-wider">
-                      {t('programs.repsRange', { sets: progressionStatus.targetSets, min: progressionStatus.targetRepsMin, max: progressionStatus.targetRepsMax })}
-                    </Text>
-                    {progressionStatus.lastPerformance && (
-                      <Text className="text-text text-xs mt-0.5 font-medium">
-                        {t('programs.lastPerformance', { weight: progressionStatus.lastPerformance.weight, reps: progressionStatus.lastPerformance.reps })}
-                      </Text>
-                    )}
-                    {progressionStatus.isAtTop && (
-                      <Text className="text-primary text-2xs font-bold mt-1">{t('programs.atTopRange')}</Text>
-                    )}
-                  </View>
-                  <Text className="text-sm">
-                    {progressionStatus.trend === 'up' ? t('programs.trendUp') : progressionStatus.trend === 'down' ? t('programs.trendDown') : t('programs.trendFlat')}
+        {/* Double Progression Banner */}
+        {activeProgram && progressionStatus && (
+          <View className="mx-4 mt-2">
+            <View className="bg-primary/5 p-3 rounded-xl border border-primary/20">
+              <View className="flex-row justify-between items-center">
+                <View className="flex-1">
+                  <Text className="text-subtext text-2xs font-bold uppercase tracking-wider">
+                    {t('programs.repsRange', { sets: progressionStatus.targetSets, min: progressionStatus.targetRepsMin, max: progressionStatus.targetRepsMax })}
                   </Text>
+                  {progressionStatus.lastPerformance && (
+                    <Text className="text-text text-xs mt-0.5 font-medium">
+                      {t('programs.lastPerformance', { weight: progressionStatus.lastPerformance.weight, reps: progressionStatus.lastPerformance.reps })}
+                    </Text>
+                  )}
+                  {progressionStatus.isAtTop && (
+                    <Text className="text-primary text-2xs font-bold mt-1">{t('programs.atTopRange')}</Text>
+                  )}
                 </View>
+                <Text className="text-sm">
+                  {progressionStatus.trend === 'up' ? t('programs.trendUp') : progressionStatus.trend === 'down' ? t('programs.trendDown') : t('programs.trendFlat')}
+                </Text>
               </View>
             </View>
-          )}
-
-          {/* Saved Sets List */}
-          <View className="flex-1 px-4">
-            <Text className="text-subtext text-xs font-bold uppercase tracking-widest mb-2 mt-2">
-              {t('exercise.registeredSetsCount', { count: sessionSets?.length || 0 })}
-            </Text>
-              <FlatList
-               data={sessionSets}
-               keyExtractor={(item) => item.id.toString()}
-               contentContainerStyle={{ paddingBottom: 20 }}
-               renderItem={({ item, index }) => (
-                 <SetCard
-                   key={item.id}
-                   index={index}
-                   setNumber={item.setNumber}
-                   weight={item.weightKg}
-                   reps={item.reps || undefined}
-                   duration={item.durationSeconds || undefined}
-                   rir={item.rir}
-                   isWarmup={item.isWarmup || false}
-                   isEdited={item.isEdited || false}
-                   onEdit={() => handleEditSet(item.id)}
-                   onDelete={() => handleDeleteSet(item.id)}
-                 />
-               )}
-              ListEmptyComponent={
-                <View className="py-8">
-                  <Text className="text-subtext text-center">{t('exerciseSession.noSetsYet')}</Text>
-                </View>
-              }
-            />
           </View>
+        )}
 
-          {/* Input Area */}
-          <View
-            className="bg-card p-3 rounded-t-3xl border-t border-border shadow-lg"
-            style={{ paddingBottom: 12 + insets.bottom }}
-          >
-            {/* Warm-Up Mode Toggle */}
-            <View className="flex-row items-center justify-between mb-3 py-1.5 bg-background rounded-lg px-3">
-              <View className="flex-row items-center gap-2">
-                <Text className="text-lg">🔥</Text>
-                <Text className="text-text font-bold text-xs">{t('exerciseSession.warmup')}</Text>
-              </View>
-              <TouchableOpacity
-                onPress={() => setIsWarmupMode(!isWarmupMode)}
-                className={`w-12 h-7 rounded-full p-0.5 transition-colors ${isWarmupMode ? 'bg-warning' : 'bg-border'}`}
-                {...a11y.warmupSwitch(isWarmupMode)}
-              >
-                <View
-                  className={`w-5 h-5 rounded-full bg-white shadow-sm transition-all ${isWarmupMode ? 'translate-x-5' : 'translate-x-0'}`}
-                />
-              </TouchableOpacity>
+        <SetList
+          sessionSets={sessionSets}
+          t={t}
+          handleEditSet={handleEditSet}
+          handleDeleteSet={handleDeleteSet}
+        />
+
+        {/* Input Area */}
+        <View
+          className="bg-card p-3 rounded-t-3xl border-t border-border shadow-lg"
+          style={{ paddingBottom: 12 + insets.bottom }}
+        >
+          {/* Warm-Up Mode Toggle */}
+          <View className="flex-row items-center justify-between mb-3 py-1.5 bg-background rounded-lg px-3">
+            <View className="flex-row items-center gap-2">
+              <Text className="text-lg">🔥</Text>
+              <Text className="text-text font-bold text-xs">{t('exerciseSession.warmup')}</Text>
             </View>
+            <TouchableOpacity
+              onPress={() => setIsWarmupMode(!isWarmupMode)}
+              className={`w-12 h-7 rounded-full p-0.5 transition-colors ${isWarmupMode ? 'bg-warning' : 'bg-border'}`}
+              {...a11y.warmupSwitch(isWarmupMode)}
+            >
+              <View
+                className={`w-5 h-5 rounded-full bg-white shadow-sm transition-all ${isWarmupMode ? 'translate-x-5' : 'translate-x-0'}`}
+              />
+            </TouchableOpacity>
+          </View>
           {exerciseType === 'duration' ? (
             <View className="items-center mb-4">
               <Text className="text-text font-mono text-6xl font-bold mb-4">
@@ -775,52 +424,20 @@ export default function ExerciseScreen() {
           </View>
         </View>
 
-        {/* History Modal */}
-        <Modal visible={historyVisible} animationType="slide" presentationStyle="pageSheet">
-          <View className="flex-1 bg-background p-4">
-            <View className="flex-row justify-between items-center mb-4 mt-2">
-              <Text className="text-text text-xl font-bold uppercase">{t("exerciseSession.history")}</Text>
-              <TouchableOpacity onPress={() => setHistoryVisible(false)}>
-                <Text className="text-primary font-bold uppercase">{t("common.close")}</Text>
-              </TouchableOpacity>
-            </View>
-            <FlatList
-              data={historyData}
-              keyExtractor={(item, index) => index.toString()}
-              renderItem={({ item }) => {
-                const date = new Date(item.date);
-                return (
-                  <View className="bg-card p-3 mb-2 rounded border border-border flex-row justify-between items-center">
-                    <Text className="text-subtext font-mono text-xs">
-                      {date.toLocaleDateString(getLocaleForLanguage(language))}
-                    </Text>
-                    <Text className="text-text font-bold">
-                      {item.weight}kg × {item.duration ? `${item.duration}s` : item.reps}
-                    </Text>
-                    {item.rir !== null && (
-                      <Text className="text-subtext text-xs">RIR {item.rir}</Text>
-                    )}
-                  </View>
-                );
-              }}
-            />
-          </View>
-        </Modal>
+        <ExerciseHistoryModal
+          visible={historyVisible}
+          onClose={() => setHistoryVisible(false)}
+          historyData={historyData}
+          t={t}
+          language={language}
+        />
 
-        {/* Rest Timer Bottom Sheet */}
-        <RestTimer
-          visible={timerStatus !== 'idle'}
-          seconds={timerSeconds || 0}
-          status={timerStatus}
-          onClose={() => {
-            setTimerStatus('idle');
-            setTimerSeconds(null);
-          }}
-          onSkip={() => {
-            setTimerStatus('idle');
-            setTimerSeconds(null);
-          }}
-          onAddTime={addTime}
+        <RestTimerBar
+          timerStatus={timerStatus}
+          timerSeconds={timerSeconds}
+          setTimerStatus={setTimerStatus}
+          setTimerSeconds={setTimerSeconds}
+          addTime={addTime}
           nextExerciseName={nextExercise?.name}
         />
 
@@ -846,74 +463,12 @@ export default function ExerciseScreen() {
           }}
         />
 
-        {/* RIR Explainer Modal */}
-        <Modal visible={showRirExplainer} animationType="fade" transparent onRequestClose={() => setShowRirExplainer(false)}>
-          <TouchableOpacity
-            activeOpacity={1}
-            className="flex-1 justify-center items-center bg-black/40 p-6"
-            onPress={() => setShowRirExplainer(false)}
-          >
-            <TouchableOpacity
-              activeOpacity={1}
-              className="bg-card rounded-2xl p-6 max-w-sm w-full shadow-xl border border-border"
-              onPress={(e) => e.stopPropagation()}
-            >
-              <View className="flex-row justify-between items-center mb-4">
-                <Text className="text-text text-xl font-bold">{t('exercise.rirQuestion')}</Text>
-                <TouchableOpacity onPress={() => setShowRirExplainer(false)}>
-                  <Text className="text-subtext text-2xl font-bold">✕</Text>
-                </TouchableOpacity>
-              </View>
-
-              <View className="space-y-4">
-                <View className="flex-row items-start gap-3">
-                  <View className="bg-danger/10 p-2 rounded-lg">
-                    <Text className="text-2xl">0-1</Text>
-                  </View>
-                  <View className="flex-1">
-                    <Text className="text-text font-bold text-base mb-1">{t("exercise.rirStrong")}</Text>
-                    <Text className="text-subtext text-sm">{t("exerciseSession.next")}</Text>
-                  </View>
-                </View>
-
-                <View className="flex-row items-start gap-3">
-                  <View className="bg-success/10 p-2 rounded-lg">
-                    <Text className="text-2xl">2-3</Text>
-                  </View>
-                  <View className="flex-1">
-                    <Text className="text-text font-bold text-base mb-1">{t("exercise.rirModerate")}</Text>
-                    <Text className="text-subtext text-sm">{t("exercise.rirModerateDesc")}</Text>
-                  </View>
-                </View>
-
-                <View className="flex-row items-start gap-3">
-                  <View className="bg-secondary/10 p-2 rounded-lg">
-                    <Text className="text-2xl">4-5</Text>
-                  </View>
-                  <View className="flex-1">
-                    <Text className="text-text font-bold text-base mb-1">{t("exercise.rirLight")}</Text>
-                    <Text className="text-subtext text-sm">{t("exercise.rirLightDesc")}</Text>
-                  </View>
-                </View>
-
-                <View className="bg-background p-3 rounded-lg border border-border mt-4">
-                  <Text className="text-subtext text-xs leading-5">
-                    {t("exercise.rirExplainer")}
-                  </Text>
-                </View>
-              </View>
-
-              <TouchableOpacity
-                onPress={() => setShowRirExplainer(false)}
-                className="mt-6 bg-primary p-3 rounded-xl items-center"
-              >
-                <Text className="text-white font-bold text-base uppercase">{t('common.understood')}</Text>
-              </TouchableOpacity>
-            </TouchableOpacity>
-          </TouchableOpacity>
-        </Modal>
+        <RirExplainerModal
+          visible={showRirExplainer}
+          onClose={() => setShowRirExplainer(false)}
+          t={t}
+        />
       </View>
     </KeyboardAvoidingView>
   );
 }
-

--- a/components/session/ExerciseHeader.tsx
+++ b/components/session/ExerciseHeader.tsx
@@ -1,0 +1,102 @@
+import type { AccessibilityProps } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import Animated, { FadeInRight, FadeOutLeft } from 'react-native-reanimated';
+import { Stopwatch } from '../Stopwatch';
+import { ProgressBar } from '../ProgressBar';
+
+type TranslationFn = (key: string, options?: Record<string, string | number>) => string;
+
+interface ExerciseHeaderProps {
+  insetsTop: number;
+  totalExercises: number;
+  completedExercisesCount: number;
+  t: TranslationFn;
+  startTime: number;
+  onOpenHistory: () => void;
+  a11yHistory: AccessibilityProps;
+  exerciseId: number;
+  currentName: string;
+  currentSetNumber: number;
+  targetInfo: { sets: number; reps: string } | null;
+  routineRest: number | null;
+  target: string;
+  notes: string;
+}
+
+export function ExerciseHeader({
+  insetsTop,
+  totalExercises,
+  completedExercisesCount,
+  t,
+  startTime,
+  onOpenHistory,
+  a11yHistory,
+  exerciseId,
+  currentName,
+  currentSetNumber,
+  targetInfo,
+  routineRest,
+  target,
+  notes,
+}: ExerciseHeaderProps) {
+  return (
+    <View className="bg-card border-b border-border" style={{ paddingTop: insetsTop }}>
+      <View className="p-4">
+        {/* Progress Bar */}
+        {totalExercises > 0 && (
+          <View className="mb-4">
+            <ProgressBar
+              current={completedExercisesCount}
+              total={totalExercises}
+              variant="compact"
+              showLabel={true}
+            />
+          </View>
+        )}
+
+        <View className="flex-row justify-between items-center mb-2">
+          <View className="flex-row items-baseline gap-2 flex-1">
+            <Text className="text-subtext text-2xs font-bold uppercase tracking-widest">{t("exerciseSession.time")}</Text>
+            <Stopwatch startTime={startTime} />
+          </View>
+          <TouchableOpacity
+            onPress={onOpenHistory}
+            className="bg-background px-2 py-1 rounded-lg border border-border"
+            {...a11yHistory}
+          >
+            <Text className="text-subtext text-2xs font-bold uppercase">{t("exerciseSession.history")}</Text>
+          </TouchableOpacity>
+        </View>
+
+        <Animated.View 
+          key={`header-${exerciseId}`} 
+          entering={FadeInRight.duration(300)} 
+          exiting={FadeOutLeft.duration(300)}
+        >
+          <View className="flex-row justify-between items-start">
+            <View className="flex-1 mr-3">
+              <Text className="text-text text-xl font-bold" numberOfLines={2}>{currentName}</Text>
+              <View className="flex-row items-center gap-2 mt-1.5">
+                <Text className="text-primary text-xs font-semibold bg-primary/10 px-2 py-0.5 rounded-md">
+                  S{currentSetNumber}{targetInfo ? `/${targetInfo.sets}` : ''}
+                </Text>
+                {routineRest && (
+                  <Text className="text-subtext text-2xs bg-background px-2 py-0.5 rounded-md border border-border">
+                    ⏱ {routineRest}s
+                  </Text>
+                )}
+              </View>
+            </View>
+          </View>
+
+          {(target || notes) && (
+            <View className="mt-2 bg-background p-2 rounded-lg border border-border">
+              {target && <Text className="text-primary font-semibold text-xs">🎯 {target}</Text>}
+              {notes && <Text className="text-subtext text-2xs italic mt-0.5">📝 {notes}</Text>}
+            </View>
+          )}
+        </Animated.View>
+      </View>
+    </View>
+  );
+}

--- a/components/session/ExerciseHistoryModal.tsx
+++ b/components/session/ExerciseHistoryModal.tsx
@@ -1,0 +1,62 @@
+import { View, Text, Modal, TouchableOpacity, FlatList } from 'react-native';
+import { getLocaleForLanguage, Language } from '../../src/i18n/index';
+
+type TranslationFn = (key: string, options?: Record<string, string | number>) => string;
+
+interface ExerciseHistoryItem {
+  sessionId: number;
+  date: number;
+  weight: number | null;
+  reps: number | null;
+  duration: number | null;
+  rir: number | null;
+}
+
+interface ExerciseHistoryModalProps {
+  visible: boolean;
+  onClose: () => void;
+  historyData: ExerciseHistoryItem[];
+  t: TranslationFn;
+  language: Language;
+}
+
+export function ExerciseHistoryModal({
+  visible,
+  onClose,
+  historyData,
+  t,
+  language,
+}: ExerciseHistoryModalProps) {
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet">
+      <View className="flex-1 bg-background p-4">
+        <View className="flex-row justify-between items-center mb-4 mt-2">
+          <Text className="text-text text-xl font-bold uppercase">{t("exerciseSession.history")}</Text>
+          <TouchableOpacity onPress={onClose}>
+            <Text className="text-primary font-bold uppercase">{t("common.close")}</Text>
+          </TouchableOpacity>
+        </View>
+        <FlatList
+          data={historyData}
+          keyExtractor={(item, index) => index.toString()}
+          renderItem={({ item }) => {
+            const date = new Date(item.date);
+            return (
+              <View className="bg-card p-3 mb-2 rounded border border-border flex-row justify-between items-center">
+                <Text className="text-subtext font-mono text-xs">
+                  {date.toLocaleDateString(getLocaleForLanguage(language))}
+                </Text>
+                <Text className="text-text font-bold">
+                  {item.weight}kg × {item.duration ? `${item.duration}s` : item.reps}
+                </Text>
+                {item.rir !== null && (
+                  <Text className="text-subtext text-xs">RIR {item.rir}</Text>
+                )}
+              </View>
+            );
+          }}
+        />
+      </View>
+    </Modal>
+  );
+}

--- a/components/session/RestTimerBar.tsx
+++ b/components/session/RestTimerBar.tsx
@@ -1,0 +1,37 @@
+import { RestTimer } from '../RestTimer';
+
+interface RestTimerBarProps {
+  timerStatus: 'idle' | 'running' | 'finished';
+  timerSeconds: number | null;
+  setTimerStatus: (status: 'idle' | 'running' | 'finished') => void;
+  setTimerSeconds: (seconds: number | null) => void;
+  addTime: (sec: number) => void;
+  nextExerciseName?: string;
+}
+
+export function RestTimerBar({
+  timerStatus,
+  timerSeconds,
+  setTimerStatus,
+  setTimerSeconds,
+  addTime,
+  nextExerciseName,
+}: RestTimerBarProps) {
+  return (
+    <RestTimer
+      visible={timerStatus !== 'idle'}
+      seconds={timerSeconds || 0}
+      status={timerStatus}
+      onClose={() => {
+        setTimerStatus('idle');
+        setTimerSeconds(null);
+      }}
+      onSkip={() => {
+        setTimerStatus('idle');
+        setTimerSeconds(null);
+      }}
+      onAddTime={addTime}
+      nextExerciseName={nextExerciseName}
+    />
+  );
+}

--- a/components/session/RirExplainerModal.tsx
+++ b/components/session/RirExplainerModal.tsx
@@ -1,0 +1,83 @@
+import { View, Text, Modal, TouchableOpacity } from 'react-native';
+
+type TranslationFn = (key: string, options?: Record<string, string | number>) => string;
+
+interface RirExplainerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  t: TranslationFn;
+}
+
+export function RirExplainerModal({
+  visible,
+  onClose,
+  t,
+}: RirExplainerModalProps) {
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
+      <TouchableOpacity
+        activeOpacity={1}
+        className="flex-1 justify-center items-center bg-black/40 p-6"
+        onPress={onClose}
+      >
+        <TouchableOpacity
+          activeOpacity={1}
+          className="bg-card rounded-2xl p-6 max-w-sm w-full shadow-xl border border-border"
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View className="flex-row justify-between items-center mb-4">
+            <Text className="text-text text-xl font-bold">{t('exercise.rirQuestion')}</Text>
+            <TouchableOpacity onPress={onClose}>
+              <Text className="text-subtext text-2xl font-bold">✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          <View className="space-y-4">
+            <View className="flex-row items-start gap-3">
+              <View className="bg-danger/10 p-2 rounded-lg">
+                <Text className="text-2xl">0-1</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-text font-bold text-base mb-1">{t("exercise.rirStrong")}</Text>
+                <Text className="text-subtext text-sm">{t("exerciseSession.next")}</Text>
+              </View>
+            </View>
+
+            <View className="flex-row items-start gap-3">
+              <View className="bg-success/10 p-2 rounded-lg">
+                <Text className="text-2xl">2-3</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-text font-bold text-base mb-1">{t("exercise.rirModerate")}</Text>
+                <Text className="text-subtext text-sm">{t("exercise.rirModerateDesc")}</Text>
+              </View>
+            </View>
+
+            <View className="flex-row items-start gap-3">
+              <View className="bg-secondary/10 p-2 rounded-lg">
+                <Text className="text-2xl">4-5</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-text font-bold text-base mb-1">{t("exercise.rirLight")}</Text>
+                <Text className="text-subtext text-sm">{t("exercise.rirLightDesc")}</Text>
+              </View>
+            </View>
+
+            <View className="bg-background p-3 rounded-lg border border-border mt-4">
+              <Text className="text-subtext text-xs leading-5">
+                {t("exercise.rirExplainer")}
+              </Text>
+            </View>
+          </View>
+
+          <TouchableOpacity
+            onPress={onClose}
+            className="mt-6 bg-primary p-3 rounded-xl items-center"
+          >
+            <Text className="text-white font-bold text-base uppercase">{t('common.understood')}</Text>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </TouchableOpacity>
+    </Modal>
+  );
+}

--- a/components/session/SetList.tsx
+++ b/components/session/SetList.tsx
@@ -1,0 +1,52 @@
+import { View, Text, FlatList } from 'react-native';
+import SetCard from '../SetCard';
+import { Set } from '../../src/types';
+
+type TranslationFn = (key: string, options?: Record<string, string | number>) => string;
+
+interface SetListProps {
+  sessionSets: Set[];
+  t: TranslationFn;
+  handleEditSet: (setId: number) => void;
+  handleDeleteSet: (setId: number) => void;
+}
+
+export function SetList({
+  sessionSets,
+  t,
+  handleEditSet,
+  handleDeleteSet,
+}: SetListProps) {
+  return (
+    <View className="flex-1 px-4">
+      <Text className="text-subtext text-xs font-bold uppercase tracking-widest mb-2 mt-2">
+        {t('exercise.registeredSetsCount', { count: sessionSets?.length || 0 })}
+      </Text>
+      <FlatList
+        data={sessionSets}
+        keyExtractor={(item) => item.id.toString()}
+        contentContainerStyle={{ paddingBottom: 20 }}
+        renderItem={({ item, index }) => (
+          <SetCard
+            key={item.id}
+            index={index}
+            setNumber={item.setNumber}
+            weight={item.weightKg}
+            reps={item.reps || undefined}
+            duration={item.durationSeconds || undefined}
+            rir={item.rir}
+            isWarmup={item.isWarmup || false}
+            isEdited={item.isEdited || false}
+            onEdit={() => handleEditSet(item.id)}
+            onDelete={() => handleDeleteSet(item.id)}
+          />
+        )}
+        ListEmptyComponent={
+          <View className="py-8">
+            <Text className="text-subtext text-center">{t('exerciseSession.noSetsYet')}</Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -8,3 +8,6 @@ export { useSessionTimer } from './use-session-timer';
 export { useSessionUndo } from './use-session-undo';
 export { useSessionPersistence } from './use-session-persistence';
 export { checkPersonalRecords } from './use-personal-records';
+export { useExerciseSets } from './use-exercise-sets';
+export { useProgression } from './use-progression';
+

--- a/hooks/use-exercise-sets.ts
+++ b/hooks/use-exercise-sets.ts
@@ -1,0 +1,392 @@
+import { useState, useEffect, useCallback } from 'react';
+import { db } from '../src/db/client';
+import { sets, exercises, sessions, routineExercises } from '../src/db/schema';
+import { eq, and, desc, isNull, ne } from 'drizzle-orm';
+import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
+import { parseTargetSets } from '../src/utils/exercise';
+import { logger } from '../services/logger';
+import { Set } from '../src/types';
+import { setInputSchema } from '../src/validators/forms';
+import { useI18n } from '../src/i18n/index';
+import { useHaptics } from './use-haptics';
+import { checkPersonalRecords } from './use-personal-records';
+import { useSessionTimer } from './use-session-timer';
+import { useSessionUndo } from './use-session-undo';
+
+export interface RoutineExerciseListItem {
+  id: number;
+  name: string;
+  target: string | null;
+  notes: string | null;
+  restSeconds: number | null;
+}
+
+export interface UseExerciseSetsProps {
+  sessionId: number;
+  exerciseId: number;
+  routineId: number | null;
+  exerciseName: string;
+  routineRest: number | null;
+}
+
+export function useExerciseSets({
+  sessionId,
+  exerciseId,
+  routineId,
+  exerciseName,
+  routineRest,
+}: UseExerciseSetsProps) {
+  const { t, language } = useI18n();
+  const { trigger } = useHaptics();
+
+  const [exerciseType, setExerciseType] = useState('strength');
+  const [currentName, setCurrentName] = useState(exerciseName);
+  const [weight, setWeight] = useState('');
+  const [reps, setReps] = useState('');
+  const [duration, setDuration] = useState('');
+  const [rir, setRir] = useState(2);
+  const [sessionSets, setSessionSets] = useState<Set[]>([]);
+  const [nextExercise, setNextExercise] = useState<RoutineExerciseListItem | null>(null);
+  const [allExercises, setAllExercises] = useState<RoutineExerciseListItem[]>([]);
+  const [isWarmupMode, setIsWarmupMode] = useState(false);
+
+  const [historyVisible, setHistoryVisible] = useState(false);
+  const [historyData, setHistoryData] = useState<{ sessionId: number; date: number; weight: number | null; reps: number | null; duration: number | null; rir: number | null }[]>([]);
+
+  // Timer Hook
+  const timer = useSessionTimer();
+  const { 
+    timerSeconds, timerStatus, 
+    setTimerSeconds, setTimerTarget, setTimerStatus, 
+    addTime, activeSetTime, 
+    isActiveSetRunning, toggleActiveSet 
+  } = timer;
+
+  // Undo Hook
+  const { 
+    lastSavedSet, setLastSavedSet, undoTimeoutRef, handleUndo: hookHandleUndo 
+  } = useSessionUndo();
+
+  // Loading state
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Toast state
+  const [toast, setToast] = useState({ visible: false, message: '', type: 'success' as 'success' | 'error' | 'info' });
+
+  // Set Editor state
+  const [editingSet, setEditingSet] = useState<Set | null>(null);
+  const [showSetEditor, setShowSetEditor] = useState(false);
+
+  // Track completed exercises by target sets
+  const { data: allSessionSets } = useLiveQuery(
+    db.select({ exerciseId: sets.exerciseId })
+      .from(sets)
+      .where(and(eq(sets.sessionId, sessionId), isNull(sets.deletedAt)))
+  );
+
+  // Count completed exercises (based on target sets met)
+  const completedExercisesCount = allExercises.reduce((count, exercise) => {
+    const targetSets = parseTargetSets(exercise.target);
+    const doneSets = allSessionSets?.filter(s => s.exerciseId === exercise.id).length || 0;
+
+    if (targetSets !== null) {
+      return doneSets >= targetSets ? count + 1 : count;
+    }
+    return doneSets > 0 ? count + 1 : count;
+  }, 0);
+
+  const loadData = useCallback(async () => {
+    try {
+      setNextExercise(null);
+
+      const exData = await db.select().from(exercises).where(eq(exercises.id, exerciseId));
+      if (exData.length > 0) {
+        setExerciseType(exData[0].type);
+        setCurrentName(exData[0].name);
+      }
+
+      const data = await db.select()
+        .from(sets)
+        .where(and(eq(sets.sessionId, sessionId), eq(sets.exerciseId, exerciseId), isNull(sets.deletedAt)))
+        .orderBy(sets.setNumber);
+      setSessionSets(data);
+
+      if (data.length === 0) {
+        const lastSet = await db.select({ weight: sets.weightKg })
+          .from(sets)
+          .where(and(eq(sets.exerciseId, exerciseId), isNull(sets.deletedAt)))
+          .orderBy(desc(sets.createdAt))
+          .limit(1);
+
+        if (lastSet.length > 0 && lastSet[0].weight) {
+          setWeight(lastSet[0].weight.toString());
+        }
+      }
+
+      if (routineId) {
+        const routineList = await db.select({
+          id: exercises.id,
+          name: exercises.name,
+          target: routineExercises.target,
+          notes: routineExercises.notes,
+          restSeconds: routineExercises.restSeconds
+        })
+          .from(routineExercises)
+          .innerJoin(exercises, eq(routineExercises.exerciseId, exercises.id))
+          .where(eq(routineExercises.routineId, routineId))
+          .orderBy(routineExercises.orderIndex);
+
+        setAllExercises(routineList);
+
+        const currentIndex = routineList.findIndex(e => e.id === exerciseId);
+        if (currentIndex !== -1 && currentIndex < routineList.length - 1) {
+          const next = routineList[currentIndex + 1];
+          setNextExercise(next);
+        }
+      }
+    } catch (e) {
+      logger.error(t('common.operationError'), e);
+    }
+  }, [sessionId, exerciseId, routineId, t]);
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const history = await db.select({
+        sessionId: sets.sessionId,
+        date: sessions.startTime,
+        weight: sets.weightKg,
+        reps: sets.reps,
+        duration: sets.durationSeconds,
+        rir: sets.rir
+      })
+        .from(sets)
+        .innerJoin(sessions, eq(sets.sessionId, sessions.id))
+        .where(and(
+          eq(sets.exerciseId, exerciseId),
+          ne(sets.sessionId, sessionId),
+          isNull(sets.deletedAt),
+          isNull(sessions.deletedAt)
+        ))
+        .limit(20);
+
+      history.sort((a, b) => b.date - a.date);
+      setHistoryData(history);
+    } catch (e) {
+      logger.error(t("exercise.sqlHistoryError"), e);
+    }
+  }, [exerciseId, sessionId, t]);
+
+  useEffect(() => {
+    loadData();
+    loadHistory();
+  }, [loadData, loadHistory]);
+
+  const handleSaveSet = useCallback(async (overrideDuration?: number) => {
+    if (isSaving) return;
+
+    const isDuration = exerciseType === 'duration';
+
+    const finalDuration = overrideDuration !== undefined ? overrideDuration : (duration ? Number(duration) : 0);
+    const finalReps = reps ? Number(reps) : 0;
+
+    // Validate with Zod
+    const setValidation = setInputSchema.safeParse({
+      weightKg: Number(weight) || 0,
+      reps: isDuration ? 0 : finalReps,
+      durationSeconds: isDuration ? finalDuration : null,
+      rir: isDuration ? null : Number(rir),
+      isWarmup: isWarmupMode,
+    });
+    if (!setValidation.success) {
+      const msg = setValidation.error.issues[0]?.message || t('common.invalidData');
+      setToast({ visible: true, message: msg, type: 'error' });
+      return;
+    }
+    // Extra business logic validation
+    if (isDuration && finalDuration <= 0) {
+      setToast({ visible: true, message: t('exercise.enterDuration'), type: 'error' });
+      return;
+    }
+    if (!isDuration && finalReps <= 0) {
+      setToast({ visible: true, message: t('exercise.enterReps'), type: 'error' });
+      return;
+    }
+    if (!isDuration && !weight) {
+      setToast({ visible: true, message: t('exercise.enterWeight'), type: 'error' });
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const nextSetNumber = (sessionSets?.length || 0) + 1;
+
+      const result = await db.insert(sets).values({
+        sessionId,
+        exerciseId,
+        exerciseName: currentName,
+        setNumber: nextSetNumber,
+        weightKg: setValidation.data.weightKg,
+        reps: isDuration ? 0 : finalReps,
+        durationSeconds: isDuration ? finalDuration : null,
+        rir: isDuration ? null : Number(rir),
+        isWarmup: isWarmupMode,
+      }).returning();
+
+      // Store for undo
+      setLastSavedSet(result[0]);
+
+      // Clear undo after 10 seconds
+      if (undoTimeoutRef.current) {
+        clearTimeout(undoTimeoutRef.current);
+      }
+      undoTimeoutRef.current = setTimeout(() => {
+        setLastSavedSet(null);
+      }, 10000);
+
+      await loadData();
+
+      // Check for Personal Records (only for non-warmup strength sets)
+      if (!isWarmupMode && !isDuration && result[0]) {
+        const prResult = await checkPersonalRecords({
+          exerciseId,
+          sessionId,
+          savedSet: result[0],
+          isWarmup: isWarmupMode,
+        });
+
+        if (prResult.isWeightPR || prResult.isRepsPR) {
+          trigger('success');
+          setToast({ visible: true, message: t('finish.prText'), type: 'success' });
+        }
+      }
+
+      setReps('');
+      setDuration('');
+
+      if (!isDuration) {
+        const restTime = routineRest || 90;
+        setTimerTarget(Date.now() + restTime * 1000);
+        setTimerStatus('running');
+      }
+
+    } catch (e) {
+      logger.error(t('common.operationError'), e);
+      setToast({ visible: true, message: t('exercise.saveSetError'), type: 'error' });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isSaving, exerciseType, duration, reps, weight, rir, sessionId, exerciseId, currentName, sessionSets, routineRest, undoTimeoutRef, loadData, isWarmupMode, t, trigger, setLastSavedSet, setTimerStatus, setTimerTarget]);
+
+  const handleUndo = useCallback(async () => {
+    await hookHandleUndo({
+      exerciseId,
+      sessionId,
+      exerciseType,
+      setSessionSets,
+      setCurrentName,
+      setToast,
+    });
+  }, [hookHandleUndo, exerciseId, sessionId, exerciseType, setSessionSets, setCurrentName, setToast]);
+
+  const handleDeleteSet = useCallback(async (setId: number) => {
+    try {
+      await db.update(sets).set({ deletedAt: Date.now() }).where(eq(sets.id, setId));
+      await loadData();
+      setToast({ visible: true, message: t('exercise.setDeleted'), type: 'success' });
+    } catch (e) {
+      logger.error(t('common.operationError'), e);
+      setToast({ visible: true, message: t('exercise.deleteSetError'), type: 'error' });
+    }
+  }, [loadData, t]);
+
+  const handleEditSet = useCallback(async (setId: number) => {
+    try {
+      const setData = await db.select().from(sets).where(and(eq(sets.id, setId), isNull(sets.deletedAt)));
+      if (setData.length > 0) {
+        setEditingSet(setData[0]);
+        setShowSetEditor(true);
+      }
+    } catch (e) {
+      logger.error(t('common.operationError'), e);
+      setToast({ visible: true, message: t('exercise.loadSetError'), type: 'error' });
+    }
+  }, [t]);
+
+  const handleSaveEditedSet = useCallback(async (weight: number, reps?: number, duration?: number, rir?: number) => {
+    if (!editingSet) return;
+    
+    try {
+      await db.update(sets)
+        .set({
+          weightKg: weight,
+          reps: reps || editingSet.reps,
+          durationSeconds: duration || editingSet.durationSeconds,
+          rir: rir || editingSet.rir,
+          isEdited: true,
+        })
+        .where(eq(sets.id, editingSet.id));
+      
+      await loadData();
+      setShowSetEditor(false);
+      setEditingSet(null);
+      setToast({ visible: true, message: t('exercise.setEdited'), type: 'success' });
+    } catch (e) {
+      logger.error(t('common.operationError'), e);
+      setToast({ visible: true, message: t('exercise.editSetError'), type: 'error' });
+    }
+  }, [editingSet, loadData, t]);
+
+  return {
+    exerciseType,
+    setExerciseType,
+    currentName,
+    setCurrentName,
+    weight,
+    setWeight,
+    reps,
+    setReps,
+    duration,
+    setDuration,
+    rir,
+    setRir,
+    sessionSets,
+    setSessionSets,
+    nextExercise,
+    setNextExercise,
+    allExercises,
+    setAllExercises,
+    isWarmupMode,
+    setIsWarmupMode,
+    historyVisible,
+    setHistoryVisible,
+    historyData,
+    setHistoryData,
+    timerSeconds,
+    timerStatus,
+    setTimerSeconds,
+    setTimerStatus,
+    addTime,
+    activeSetTime,
+    isActiveSetRunning,
+    toggleActiveSet,
+    lastSavedSet,
+    handleUndo,
+    isSaving,
+    toast,
+    setToast,
+    editingSet,
+    setEditingSet,
+    showSetEditor,
+    setShowSetEditor,
+    completedExercisesCount,
+    handleSaveSet,
+    handleDeleteSet,
+    handleEditSet,
+    handleSaveEditedSet,
+    loadData,
+    loadHistory,
+    t,
+    language,
+  };
+}

--- a/hooks/use-progression.ts
+++ b/hooks/use-progression.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+import { usePrograms } from './use-programs';
+import type { DoubleProgressionStatus } from '../src/types';
+
+export function useProgression(exerciseId: number, exerciseName: string) {
+  const { activeProgram, fetchActiveProgram, getDoubleProgressionStatus } = usePrograms();
+  const [progressionStatus, setProgressionStatus] = useState<DoubleProgressionStatus | null>(null);
+
+  useEffect(() => {
+    fetchActiveProgram();
+  }, [fetchActiveProgram]);
+
+  useEffect(() => {
+    if (activeProgram && exerciseId) {
+      getDoubleProgressionStatus(activeProgram.id, exerciseId, exerciseName).then(setProgressionStatus);
+    } else {
+      setProgressionStatus(null);
+    }
+  }, [activeProgram, exerciseId, exerciseName, getDoubleProgressionStatus]);
+
+  return { activeProgram, progressionStatus };
+}


### PR DESCRIPTION
## Summary
- decompose `app/session/exercise.tsx` into focused orchestration + extracted session components
- add `useExerciseSets` and `useProgression` hooks to encapsulate session/set and progression logic
- move history, set list, header, RIR explainer, and rest timer UI into dedicated session components

## Verification
- `npm run typecheck`
- `npx eslint app/session/exercise.tsx hooks/index.ts hooks/use-exercise-sets.ts hooks/use-progression.ts components/session/*.tsx`
- `npm test -- --runInBand`

Closes #54
